### PR TITLE
Don't cancel master branch

### DIFF
--- a/lib/travis_dedup.rb
+++ b/lib/travis_dedup.rb
@@ -73,7 +73,8 @@ module TravisDedup
         if seen.include?(id)
           true
         else
-          seen << id
+          # don't cancel master branch
+          seen << id if id != 'master'
           false
         end
       end


### PR DESCRIPTION
This commit prevents dedup from cancelling the master branch when using
`branches=true`
